### PR TITLE
Add README documentation for each subfolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,3 +248,143 @@ Ce projet est sous licence MIT. Consultez le fichier [LICENSE](./LICENSE) pour p
 ---
 
 Ce README est basé sur la documentation des projets intégrés et inclut des instructions spécifiques pour le déploiement sur Azure Container Apps. Si vous avez besoin d'ajouter des informations spécifiques, faites-le moi savoir !
+
+---
+
+## 📂 Structure du projet
+
+Le projet est organisé en plusieurs sous-dossiers, chacun ayant un rôle spécifique. Voici un aperçu de la structure globale du projet :
+
+- `chainlit/` : Contient le code pour l'application Chainlit.
+- `dapr/publisher/` : Contient le code pour le service de publication Dapr.
+- `dapr/subscriber/` : Contient le code pour le service de souscription Dapr.
+- `fluxjob/` : Contient le code pour le traitement des tâches de flux.
+- `uitester/` : Contient le code pour l'application de test d'interface utilisateur.
+
+---
+
+## 📁 Dossier `chainlit`
+
+Le dossier `chainlit` contient le code pour l'application Chainlit.
+
+### Contenu
+
+- `app.py` : Le fichier principal de l'application Chainlit.
+- `Dockerfile` : Le fichier Docker pour construire l'image de l'application.
+- `infraaca.sh` : Script pour déployer l'application sur Azure Container Apps.
+- `requirements.txt` : Liste des dépendances Python nécessaires pour l'application.
+
+### Instructions pour exécuter le code
+
+1. Construisez l'image Docker :
+   ```bash
+   docker build -t chainlit .
+   ```
+
+2. Exécutez le conteneur Docker :
+   ```bash
+   docker run -p 8000:8000 chainlit
+   ```
+
+---
+
+## 📁 Dossier `dapr/publisher`
+
+Le dossier `dapr/publisher` contient le code pour le service de publication Dapr.
+
+### Contenu
+
+- `app.py` : Le fichier principal du service de publication.
+- `Dockerfile` : Le fichier Docker pour construire l'image du service.
+- `infraaca.sh` : Script pour déployer le service sur Azure Container Apps.
+- `requirements.txt` : Liste des dépendances Python nécessaires pour le service.
+
+### Instructions pour exécuter le code
+
+1. Construisez l'image Docker :
+   ```bash
+   docker build -t dapr-publisher .
+   ```
+
+2. Exécutez le conteneur Docker :
+   ```bash
+   docker run -p 8000:8000 dapr-publisher
+   ```
+
+---
+
+## 📁 Dossier `dapr/subscriber`
+
+Le dossier `dapr/subscriber` contient le code pour le service de souscription Dapr.
+
+### Contenu
+
+- `app.py` : Le fichier principal du service de souscription.
+- `Dockerfile` : Le fichier Docker pour construire l'image du service.
+- `infraaca.sh` : Script pour déployer le service sur Azure Container Apps.
+- `requirements.txt` : Liste des dépendances Python nécessaires pour le service.
+- `pubsub.yaml` : Configuration Pub/Sub pour Dapr.
+- `statestore.yaml` : Configuration du magasin d'état pour Dapr.
+
+### Instructions pour exécuter le code
+
+1. Construisez l'image Docker :
+   ```bash
+   docker build -t dapr-subscriber .
+   ```
+
+2. Exécutez le conteneur Docker :
+   ```bash
+   docker run dapr-subscriber
+   ```
+
+---
+
+## 📁 Dossier `fluxjob`
+
+Le dossier `fluxjob` contient le code pour le traitement des tâches de flux.
+
+### Contenu
+
+- `blockprocessor.py` : Gestionnaire de blobs Azure.
+- `Dockerfile` : Le fichier Docker pour construire l'image du traitement des tâches.
+- `job.py` : Le fichier principal pour le traitement des tâches.
+- `msgprocessor.py` : Gestionnaire de visibilité des messages.
+- `queueprocessor.py` : Gestionnaire de file d'attente Azure.
+- `requirements.txt` : Liste des dépendances Python nécessaires pour le traitement des tâches.
+
+### Instructions pour exécuter le code
+
+1. Construisez l'image Docker :
+   ```bash
+   docker build -t fluxjob .
+   ```
+
+2. Exécutez le conteneur Docker :
+   ```bash
+   docker run fluxjob
+   ```
+
+---
+
+## 📁 Dossier `uitester`
+
+Le dossier `uitester` contient le code pour l'application de test d'interface utilisateur.
+
+### Contenu
+
+- `app.py` : Le fichier principal de l'application de test.
+- `Dockerfile` : Le fichier Docker pour construire l'image de l'application.
+- `requirements.txt` : Liste des dépendances Python nécessaires pour l'application.
+
+### Instructions pour exécuter le code
+
+1. Construisez l'image Docker :
+   ```bash
+   docker build -t uitester .
+   ```
+
+2. Exécutez le conteneur Docker :
+   ```bash
+   docker run -p 8000:8000 uitester
+   ```

--- a/chainlit/README.md
+++ b/chainlit/README.md
@@ -1,0 +1,24 @@
+# Chainlit Folder
+
+## Purpose
+
+The `chainlit` folder contains the code for the Chainlit application. This application is responsible for generating images using Stable Diffusion and FLUX models. It provides an interface for users to input prompts and receive generated images.
+
+## Instructions to Run the Code
+
+1. **Build the Docker Image:**
+   ```bash
+   docker build -t chainlit .
+   ```
+
+2. **Run the Docker Container:**
+   ```bash
+   docker run -p 8000:8000 chainlit
+   ```
+
+## Files and Their Purposes
+
+- `app.py`: The main application file for Chainlit. It contains the logic for downloading models, initializing Stable Diffusion, and handling user prompts to generate images.
+- `Dockerfile`: The Dockerfile for building the Chainlit application image.
+- `infraaca.sh`: A script for deploying the Chainlit application on Azure Container Apps.
+- `requirements.txt`: A list of Python dependencies required for the Chainlit application.

--- a/dapr/publisher/README.md
+++ b/dapr/publisher/README.md
@@ -1,0 +1,27 @@
+# Dapr Publisher
+
+## Purpose
+
+The `dapr/publisher` folder contains the code for the Dapr publisher service. This service is responsible for publishing messages to a Dapr pub/sub component.
+
+## Instructions to Run the Code
+
+1. **Build the Docker image:**
+   ```bash
+   docker build -t dapr-publisher .
+   ```
+
+2. **Run the Docker container:**
+   ```bash
+   docker run -p 8000:8000 dapr-publisher
+   ```
+
+3. **Deploy to Azure Container Apps:**
+   - Use the `infraaca.sh` script to deploy the service to Azure Container Apps.
+
+## Files and Their Purposes
+
+- `app.py`: The main file for the Dapr publisher service.
+- `Dockerfile`: The Dockerfile to build the Docker image for the service.
+- `infraaca.sh`: Script to deploy the service to Azure Container Apps.
+- `requirements.txt`: List of Python dependencies required for the service.

--- a/dapr/subscriber/README.md
+++ b/dapr/subscriber/README.md
@@ -1,0 +1,26 @@
+# Dapr Subscriber
+
+## Purpose
+
+The `dapr/subscriber` folder contains the code for the Dapr subscriber service. This service is responsible for subscribing to messages from a Dapr pub/sub component and processing them accordingly.
+
+## Instructions to Run the Code
+
+1. **Build the Docker Image:**
+   ```bash
+   docker build -t dapr-subscriber .
+   ```
+
+2. **Run the Docker Container:**
+   ```bash
+   docker run dapr-subscriber
+   ```
+
+## Contents
+
+- `app.py`: The main file for the Dapr subscriber service.
+- `Dockerfile`: The Dockerfile to build the Docker image for the service.
+- `infraaca.sh`: Script to deploy the service on Azure Container Apps.
+- `requirements.txt`: List of Python dependencies required for the service.
+- `pubsub.yaml`: Configuration file for the Dapr pub/sub component.
+- `statestore.yaml`: Configuration file for the Dapr state store component.

--- a/fluxjob/README.md
+++ b/fluxjob/README.md
@@ -1,0 +1,26 @@
+# fluxjob
+
+## Purpose
+
+The `fluxjob` folder contains the code for processing tasks related to flux. This includes downloading models, generating images, and managing Azure Blob Storage and Queue Storage.
+
+## Instructions to Run the Code
+
+1. Build the Docker image:
+   ```bash
+   docker build -t fluxjob .
+   ```
+
+2. Run the Docker container:
+   ```bash
+   docker run fluxjob
+   ```
+
+## Contents
+
+- `blockprocessor.py`: Manages Azure Blob Storage operations.
+- `Dockerfile`: Dockerfile to build the image for fluxjob.
+- `job.py`: Main script for processing flux tasks.
+- `msgprocessor.py`: Manages message visibility in Azure Queue Storage.
+- `queueprocessor.py`: Manages Azure Queue Storage operations.
+- `requirements.txt`: Lists the Python dependencies required for fluxjob.

--- a/uitester/README.md
+++ b/uitester/README.md
@@ -1,0 +1,21 @@
+# Dossier `uitester`
+
+Le dossier `uitester` contient le code pour l'application de test d'interface utilisateur.
+
+## Contenu
+
+- `app.py` : Le fichier principal de l'application de test.
+- `Dockerfile` : Le fichier Docker pour construire l'image de l'application.
+- `requirements.txt` : Liste des dépendances Python nécessaires pour l'application.
+
+## Instructions pour exécuter le code
+
+1. Construisez l'image Docker :
+   ```bash
+   docker build -t uitester .
+   ```
+
+2. Exécutez le conteneur Docker :
+   ```bash
+   docker run -p 8000:8000 uitester
+   ```


### PR DESCRIPTION
Add documentation and README files for each subfolder in the repository.

* **README.md**:
  - Add a new section for each subfolder in the repository, explaining its purpose and contents.
  - Add instructions on how to run the code in each subfolder.
  - Add a brief description of the overall project structure.

* **chainlit/README.md**:
  - Add a description of the purpose of the `chainlit` folder.
  - Add instructions on how to run the code in the `chainlit` folder.
  - Add a list of the files in the `chainlit` folder and their purposes.

* **dapr/publisher/README.md**:
  - Add a description of the purpose of the `dapr/publisher` folder.
  - Add instructions on how to run the code in the `dapr/publisher` folder.
  - Add a list of the files in the `dapr/publisher` folder and their purposes.

* **dapr/subscriber/README.md**:
  - Add a description of the purpose of the `dapr/subscriber` folder.
  - Add instructions on how to run the code in the `dapr/subscriber` folder.
  - Add a list of the files in the `dapr/subscriber` folder and their purposes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zecloud/sdcpp/pull/1?shareId=40149832-88cd-4657-8072-2dc15bb66aa5).